### PR TITLE
feature/Collation: Assume general_ci collation

### DIFF
--- a/include/dictionary-search.php
+++ b/include/dictionary-search.php
@@ -135,7 +135,7 @@ function sil_dictionary_custom_join($join) {
 				$collate = "";
 			}
 			
-			$subquery_where .= "(" . $search_table_name . ".search_strings REGEXP '^(=|-|\\\*|~)?[" . addslashes($letter) . addslashes(strtoupper($letter)) . "]' " . $collate . ")" .
+			$subquery_where .= "(" . $search_table_name . ".search_strings REGEXP '^(=|-|\\\*|~)?" . addslashes($letter) . "' " . $collate . ")" .
 			" AND relevance >= 95 AND language_code = '$key' ";
 
 			$arrNoLetters = explode(",",  $noletters);


### PR DESCRIPTION
- Used for the upgrade to utf8mb4 character sets with collation utf8mb4_general_ci
- We will need additional code if we want to do a case sensitive compare. e.g. B != b